### PR TITLE
add NewFromFile constructor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ When adding features, keep related logic in existing root files (or add another 
 - Keep package name as `jman`; exported APIs use `CamelCase`, unexported helpers use `camelCase`.
 - Preserve existing file naming style: short, responsibility-based names (`options.go`, `matchers.go`).
 - Test names follow `Test<Type>_<Method>_<Scenario>` (example: `TestObj_Equal_Unequal_MissingKeyFromActual`).
+- Prefer public interfaces that accept `jman.T` and fail via `t.Fatalf(...)` on invalid usage/inputs, instead of returning `error` values (unless explicitly requested otherwise).
 
 ## Testing Guidelines
 - Add or update tests for every behavioral change.

--- a/equal.go
+++ b/equal.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 )
 
 var (
-	ErrJSONParse = errors.New("error parsing JSON data")
-	ErrNormalize = errors.New("error normalizing JSON data")
+	ErrJSONRead        = errors.New("error reading JSON file")
+	ErrJSONParse       = errors.New("error parsing JSON data")
+	ErrNormalize       = errors.New("error normalizing JSON data")
 	ErrUnsupportedType = errors.New("unsupported type for JSON data, use either string or []byte")
 )
 
@@ -22,7 +24,7 @@ type JSONEqual interface {
 
 // New creates a new instance of type T from the provided data.
 // The data can be a JSON string, a byte slice, or an instance of type T.
-// It returns an error if the data cannot be parsed or normalized into type T.
+// It fails the test via t.Fatalf if data cannot be parsed or normalized into type T.
 func New[E JSONEqual](t T, data any) E {
 	var result E
 
@@ -47,6 +49,16 @@ func New[E JSONEqual](t T, data any) E {
 	}
 
 	return result
+}
+
+// NewFromFile creates a new instance of type E from a JSON file path.
+// It fails the test via t.Fatalf if the file can't be read or JSON can't be parsed.
+func NewFromFile[E JSONEqual](t T, path string) E {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("%v %s: %v", ErrJSONRead, path, err))
+	}
+	return New[E](t, data)
 }
 
 func normalize[T JSONEqual](data T) (T, error) {

--- a/new_from_file_test.go
+++ b/new_from_file_test.go
@@ -1,0 +1,55 @@
+package jman_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/akaswenwilk/jman"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFromFile_Obj(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "obj.json")
+	err := os.WriteFile(path, []byte(`{"key":"value","num":2}`), 0o600)
+	assert.NoError(t, err)
+
+	obj := jman.NewFromFile[jman.Obj](t, path)
+	assert.Equal(t, jman.Obj{
+		"key": "value",
+		"num": float64(2),
+	}, obj)
+}
+
+func TestNewFromFile_Arr(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "arr.json")
+	err := os.WriteFile(path, []byte(`["a",2,true]`), 0o600)
+	assert.NoError(t, err)
+
+	arr := jman.NewFromFile[jman.Arr](t, path)
+	assert.Equal(t, jman.Arr{
+		"a",
+		float64(2),
+		true,
+	}, arr)
+}
+
+func TestNewFromFile_FileNotFound(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing.json")
+	mt := newMockT(fmt.Sprintf("error reading JSON file %s:", missingPath))
+	defer mt.AssertExpectations(t)
+
+	assert.Panics(t, func() { jman.NewFromFile[jman.Obj](mt, missingPath) })
+}
+
+func TestNewFromFile_InvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	err := os.WriteFile(path, []byte(`{"a":`), 0o600)
+	assert.NoError(t, err)
+
+	mt := newMockT(`error parsing JSON data {"a"::`)
+	defer mt.AssertExpectations(t)
+
+	assert.Panics(t, func() { jman.NewFromFile[jman.Obj](mt, path) })
+}


### PR DESCRIPTION
Summary:
- add NewFromFile generic constructor to load JSON fixtures from a file path
- keep jman style by failing via t.Fatalf on file read/parse errors
- update AGENTS guideline to prefer jman.T fail-fast public interfaces
- add tests for object load, array load, missing file, and invalid JSON

Test Evidence:
- go test -run TestNewFromFile ./...
- go test ./...